### PR TITLE
Improve cleanup commands

### DIFF
--- a/org.vanillaos.ApxGUI.yml
+++ b/org.vanillaos.ApxGUI.yml
@@ -13,6 +13,9 @@ finish-args:
   - --device=dri
   - --filesystem=xdg-run/podman:ro
   - --talk-name=org.freedesktop.Flatpak
+cleanup:
+  - '*.a'
+  - /include
 
 modules:
   - name: apx
@@ -51,6 +54,8 @@ modules:
 
   - name: fast_float
     buildsystem: cmake-ninja
+    cleanup:
+      - /share
     sources:
       - type: git
         url: https://github.com/fastfloat/fast_float.git
@@ -63,6 +68,8 @@ modules:
 
   - name: simdutf
     buildsystem: cmake-ninja
+    cleanup:
+      - /lib/cmake
     sources:
       - type: git
         url: https://github.com/simdutf/simdutf.git
@@ -75,6 +82,8 @@ modules:
 
   - name: vte
     buildsystem: meson
+    cleanup:
+      - /share
     config-opts:
       - -Dapp=false
       - -Dglade=false


### PR DESCRIPTION
### Improve cleanup commands

Remove the development-related files to reduce the Flatpak size.

The installed size was reduced from 26.1 MB to 15.4 MB.

**Please don't forget to test before merging.**

### Compile pyc files

Compile pyc files to improve performance.